### PR TITLE
Replace Func with ActionContextPredicate delegate in IActionContext

### DIFF
--- a/Packages/UGF.Actions/Runtime/ActionContext.cs
+++ b/Packages/UGF.Actions/Runtime/ActionContext.cs
@@ -43,12 +43,12 @@ namespace UGF.Actions.Runtime
             return false;
         }
 
-        public T Get<TArguments, T>(TArguments arguments, Func<TArguments, T, bool> predicate)
+        public T Get<TArguments, T>(TArguments arguments, ActionContextPredicate<TArguments, T> predicate)
         {
             return TryGet(arguments, predicate, out T value) ? value : throw new ArgumentException($"Value not found by the specified predicate: '{predicate}'.");
         }
 
-        public object Get<TArguments>(TArguments arguments, Func<TArguments, object, bool> predicate)
+        public object Get<TArguments>(TArguments arguments, ActionContextPredicate<TArguments, object> predicate)
         {
             return TryGet(arguments, predicate, out object value) ? value : throw new ArgumentException($"Value not found by the specified predicate: '{predicate}'.");
         }
@@ -63,7 +63,7 @@ namespace UGF.Actions.Runtime
             return TryGet(type, out object value) ? value : throw new ArgumentException($"Value not found by the specified type: '{type}'.");
         }
 
-        public bool TryGet<TArguments, T>(TArguments arguments, Func<TArguments, T, bool> predicate, out T value)
+        public bool TryGet<TArguments, T>(TArguments arguments, ActionContextPredicate<TArguments, T> predicate, out T value)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
@@ -85,7 +85,7 @@ namespace UGF.Actions.Runtime
             return false;
         }
 
-        public bool TryGet<TArguments>(TArguments arguments, Func<TArguments, object, bool> predicate, out object value)
+        public bool TryGet<TArguments>(TArguments arguments, ActionContextPredicate<TArguments, object> predicate, out object value)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 

--- a/Packages/UGF.Actions/Runtime/ActionContextPredicate.cs
+++ b/Packages/UGF.Actions/Runtime/ActionContextPredicate.cs
@@ -1,0 +1,4 @@
+﻿namespace UGF.Actions.Runtime
+{
+    public delegate bool ActionContextPredicate<in TArguments, in TValue>(TArguments arguments, TValue value);
+}

--- a/Packages/UGF.Actions/Runtime/ActionContextPredicate.cs.meta
+++ b/Packages/UGF.Actions/Runtime/ActionContextPredicate.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6c4cc715e2514d54a4f76bb8bddaaa1a
+timeCreated: 1609768786

--- a/Packages/UGF.Actions/Runtime/IActionContext.cs
+++ b/Packages/UGF.Actions/Runtime/IActionContext.cs
@@ -7,12 +7,12 @@ namespace UGF.Actions.Runtime
     {
         void Add(object value);
         bool Remove(object value);
-        T Get<TArguments, T>(TArguments arguments, Func<TArguments, T, bool> predicate);
-        object Get<TArguments>(TArguments arguments, Func<TArguments, object, bool> predicate);
+        T Get<TArguments, T>(TArguments arguments, ActionContextPredicate<TArguments, T> predicate);
+        object Get<TArguments>(TArguments arguments, ActionContextPredicate<TArguments, object> predicate);
         T Get<T>() where T : class;
         object Get(Type type);
-        bool TryGet<TArguments, T>(TArguments arguments, Func<TArguments, T, bool> predicate, out T value);
-        bool TryGet<TArguments>(TArguments arguments, Func<TArguments, object, bool> predicate, out object value);
+        bool TryGet<TArguments, T>(TArguments arguments, ActionContextPredicate<TArguments, T> predicate, out T value);
+        bool TryGet<TArguments>(TArguments arguments, ActionContextPredicate<TArguments, object> predicate, out object value);
         bool TryGet<T>(out T value) where T : class;
         bool TryGet(Type type, out object value);
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.2",
-    "com.unity.test-framework": "1.1.18"
+    "com.unity.ide.rider": "3.0.3",
+    "com.unity.test-framework": "1.1.20"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -25,14 +25,14 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.0",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -41,11 +41,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.18",
+      "version": "1.1.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b12
-m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)
+m_EditorVersion: 2020.2.1f1
+m_EditorVersionWithRevision: 2020.2.1f1 (270dd8c3da1c)


### PR DESCRIPTION
- Add `ActionContextPredicate` delegate to use with `IActionContext`.
- Change `IActionContext.TryGet()` predicate argument type to `ActionContextPredicate` delegate.